### PR TITLE
Add Godot project scaffold with hub and district scenes

### DIFF
--- a/game/project.godot
+++ b/game/project.godot
@@ -1,0 +1,13 @@
+; Engine configuration file.
+; It's best edited using the Godot editor.
+; If you edit it manually, mind the syntax.
+
+config_version=5
+
+[application]
+config/name="Digital Citizenship: Glitches in Digital City"
+run/main_scene="res://scenes/CityHub.tscn"
+config/features=PackedStringArray("4.0")
+
+[autoload]
+game_state="*res://scripts/game_state.gd"

--- a/game/scenes/CityHub.tscn
+++ b/game/scenes/CityHub.tscn
@@ -1,0 +1,80 @@
+[gd_scene load_steps=3 format=3]
+
+[ext_resource type="Script" path="res://scripts/city_hub.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/ui/Backpack.tscn" id="2"]
+
+[node name="CityHub" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.113725, 0.109804, 0.25098, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Map" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/Map"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = 40.0
+offset_right = -40.0
+offset_bottom = -40.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/Map/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Digital City Hub"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Click a district to help Digital City!"
+horizontal_alignment = 1
+
+[node name="MapGrid" type="GridContainer" parent="CanvasLayer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+columns = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 250)
+
+[node name="SafetyButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid"]
+layout_mode = 2
+text = "Safety District"
+
+[node name="RespectButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid"]
+layout_mode = 2
+text = "Respect Plaza"
+
+[node name="InfoButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid"]
+layout_mode = 2
+text = "Info Alley"
+
+[node name="CopyrightButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid"]
+layout_mode = 2
+text = "Copyright Court"
+
+[node name="BalanceButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid"]
+layout_mode = 2
+text = "Balance Park"
+
+[node name="BackpackButton" type="Button" parent="CanvasLayer/Map/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Toggle Backpack"
+
+[node name="Backpack" parent="CanvasLayer" instance=ExtResource("2")]

--- a/game/scenes/districts/BalancePark.tscn
+++ b/game/scenes/districts/BalancePark.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/districts/balance_park.gd" id="1"]
+
+[node name="BalancePark" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.121569, 0.133333, 0.05098, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/UI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 60.0
+offset_top = 60.0
+offset_right = -60.0
+offset_bottom = -60.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/UI/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Balance Park"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Balance screen time with play, breaks, and family fun."
+autowrap_mode = 2
+horizontal_alignment = 1
+
+[node name="CompleteButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Complete Balance Challenges"
+
+[node name="BackButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Return to City Hub"

--- a/game/scenes/districts/CopyrightCourt.tscn
+++ b/game/scenes/districts/CopyrightCourt.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/districts/copyright_court.gd" id="1"]
+
+[node name="CopyrightCourt" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.180392, 0.113725, 0.066667, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/UI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 60.0
+offset_top = 60.0
+offset_right = -60.0
+offset_bottom = -60.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/UI/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Copyright Court"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Give credit where it's due and outsmart DJ Glitch's remix tricks."
+autowrap_mode = 2
+horizontal_alignment = 1
+
+[node name="CompleteButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Complete Creativity Challenges"
+
+[node name="BackButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Return to City Hub"

--- a/game/scenes/districts/InfoAlley.tscn
+++ b/game/scenes/districts/InfoAlley.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/districts/info_alley.gd" id="1"]
+
+[node name="InfoAlley" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.070588, 0.129412, 0.078431, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/UI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 60.0
+offset_top = 60.0
+offset_right = -60.0
+offset_bottom = -60.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/UI/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Info Alley"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Fact-check headlines, spot ads, and choose reliable sources."
+autowrap_mode = 2
+horizontal_alignment = 1
+
+[node name="CompleteButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Complete Information Challenges"
+
+[node name="BackButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Return to City Hub"

--- a/game/scenes/districts/RespectPlaza.tscn
+++ b/game/scenes/districts/RespectPlaza.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/districts/respect_plaza.gd" id="1"]
+
+[node name="RespectPlaza" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.133333, 0.070588, 0.176471, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/UI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 60.0
+offset_top = 60.0
+offset_right = -60.0
+offset_bottom = -60.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/UI/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Respect Plaza"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Spread kindness, decode emojis, and stop the Glitches' gossip."
+autowrap_mode = 2
+horizontal_alignment = 1
+
+[node name="CompleteButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Complete Respect Challenges"
+
+[node name="BackButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Return to City Hub"

--- a/game/scenes/districts/SafetyDistrict.tscn
+++ b/game/scenes/districts/SafetyDistrict.tscn
@@ -1,0 +1,55 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/districts/safety_district.gd" id="1"]
+
+[node name="SafetyDistrict" type="Node2D"]
+script = ExtResource("1")
+
+[node name="Background" type="ColorRect" parent="."]
+color = Color(0.062745, 0.113725, 0.160784, 1)
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="UI" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="MarginContainer" type="MarginContainer" parent="CanvasLayer/UI"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 60.0
+offset_top = 60.0
+offset_right = -60.0
+offset_bottom = -60.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/UI/MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Safety District"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Protect passwords, dodge scams, and keep personal info safe."
+autowrap_mode = 2
+horizontal_alignment = 1
+
+[node name="CompleteButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Complete Safety Challenges"
+
+[node name="BackButton" type="Button" parent="CanvasLayer/UI/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Return to City Hub"

--- a/game/scenes/ui/Backpack.tscn
+++ b/game/scenes/ui/Backpack.tscn
@@ -1,0 +1,48 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/ui/backpack.gd" id="1"]
+
+[node name="Backpack" type="Control"]
+layout_mode = 3
+anchors_preset = 3
+anchor_right = 1.0
+offset_left = -260.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = 260.0
+script = ExtResource("1")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 0.0
+offset_top = 0.0
+offset_right = 0.0
+offset_bottom = 0.0
+
+[node name="MarginContainer" type="MarginContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -8.0
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel/MarginContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="Title" type="Label" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+text = "Backpack of Wisdom"
+horizontal_alignment = 1
+
+[node name="BadgeGrid" type="GridContainer" parent="Panel/MarginContainer/VBoxContainer"]
+layout_mode = 2
+columns = 1
+size_flags_vertical = 3
+custom_minimum_size = Vector2(0, 200)

--- a/game/scripts/city_hub.gd
+++ b/game/scripts/city_hub.gd
@@ -1,0 +1,32 @@
+extends Node2D
+
+const DISTRICT_SCENES := {
+    "Safety": "res://scenes/districts/SafetyDistrict.tscn",
+    "Respect": "res://scenes/districts/RespectPlaza.tscn",
+    "Information": "res://scenes/districts/InfoAlley.tscn",
+    "Copyright": "res://scenes/districts/CopyrightCourt.tscn",
+    "Balance": "res://scenes/districts/BalancePark.tscn"
+}
+
+@onready var _backpack: Control = $CanvasLayer/Backpack
+
+func _ready() -> void:
+    _connect_button("Safety", $CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid/SafetyButton)
+    _connect_button("Respect", $CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid/RespectButton)
+    _connect_button("Information", $CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid/InfoButton)
+    _connect_button("Copyright", $CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid/CopyrightButton)
+    _connect_button("Balance", $CanvasLayer/Map/MarginContainer/VBoxContainer/MapGrid/BalanceButton)
+    $CanvasLayer/Map/MarginContainer/VBoxContainer/BackpackButton.pressed.connect(_on_backpack_pressed)
+
+func _connect_button(district_key: String, button: Button) -> void:
+    if button:
+        button.pressed.connect(func(): _on_district_selected(district_key))
+
+func _on_district_selected(district_key: String) -> void:
+    var scene_path := DISTRICT_SCENES.get(district_key, "")
+    if not scene_path.is_empty():
+        get_tree().change_scene_to_file(scene_path)
+
+func _on_backpack_pressed() -> void:
+    if _backpack:
+        _backpack.toggle_backpack()

--- a/game/scripts/districts/balance_park.gd
+++ b/game/scripts/districts/balance_park.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+# TODO: Implement Balance Park challenges:
+#  - Seesaw of Schedules activity balance puzzle.
+#  - Break Dance healthy screen-time breaks.
+#  - Dinner Bell Dash log-off mini-game.
+
+func _ready() -> void:
+    $CanvasLayer/UI/CompleteButton.pressed.connect(_on_complete_pressed)
+    $CanvasLayer/UI/BackButton.pressed.connect(_on_back_pressed)
+
+func _on_complete_pressed() -> void:
+    game_state.award_badge("Balance")
+    _return_to_hub()
+
+func _on_back_pressed() -> void:
+    _return_to_hub()
+
+func _return_to_hub() -> void:
+    get_tree().change_scene_to_file("res://scenes/CityHub.tscn")

--- a/game/scripts/districts/copyright_court.gd
+++ b/game/scripts/districts/copyright_court.gd
@@ -1,0 +1,19 @@
+extends Node2D
+
+# TODO: Implement Copyright Court cases:
+#  - DJ Glitch remix credit mechanic.
+#  - Art Gallery plaque attribution puzzle.
+
+func _ready() -> void:
+    $CanvasLayer/UI/CompleteButton.pressed.connect(_on_complete_pressed)
+    $CanvasLayer/UI/BackButton.pressed.connect(_on_back_pressed)
+
+func _on_complete_pressed() -> void:
+    game_state.award_badge("Creativity")
+    _return_to_hub()
+
+func _on_back_pressed() -> void:
+    _return_to_hub()
+
+func _return_to_hub() -> void:
+    get_tree().change_scene_to_file("res://scenes/CityHub.tscn")

--- a/game/scripts/districts/info_alley.gd
+++ b/game/scripts/districts/info_alley.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+# TODO: Implement Info Alley missions:
+#  - Headline Hijinks fact-checking challenge.
+#  - Ad Detective persuasive content hunt.
+#  - Library Link research site comparison.
+
+func _ready() -> void:
+    $CanvasLayer/UI/CompleteButton.pressed.connect(_on_complete_pressed)
+    $CanvasLayer/UI/BackButton.pressed.connect(_on_back_pressed)
+
+func _on_complete_pressed() -> void:
+    game_state.award_badge("Information")
+    _return_to_hub()
+
+func _on_back_pressed() -> void:
+    _return_to_hub()
+
+func _return_to_hub() -> void:
+    get_tree().change_scene_to_file("res://scenes/CityHub.tscn")

--- a/game/scripts/districts/respect_plaza.gd
+++ b/game/scripts/districts/respect_plaza.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+# TODO: Implement Respect Plaza activities:
+#  - Chatroom Showdown empathy dialogue tree.
+#  - Emoji Quest matching emotions.
+#  - Compliment Catapult positivity mini-game.
+
+func _ready() -> void:
+    $CanvasLayer/UI/CompleteButton.pressed.connect(_on_complete_pressed)
+    $CanvasLayer/UI/BackButton.pressed.connect(_on_back_pressed)
+
+func _on_complete_pressed() -> void:
+    game_state.award_badge("Respect")
+    _return_to_hub()
+
+func _on_back_pressed() -> void:
+    _return_to_hub()
+
+func _return_to_hub() -> void:
+    get_tree().change_scene_to_file("res://scenes/CityHub.tscn")

--- a/game/scripts/districts/safety_district.gd
+++ b/game/scripts/districts/safety_district.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+# TODO: Implement the Safety District puzzles:
+#  - RoboBob's Brain Freeze password generator.
+#  - Stranger Chat Café safe dialogue choices.
+#  - Pop-Up Arcade scam whack-a-mole.
+
+func _ready() -> void:
+    $CanvasLayer/UI/CompleteButton.pressed.connect(_on_complete_pressed)
+    $CanvasLayer/UI/BackButton.pressed.connect(_on_back_pressed)
+
+func _on_complete_pressed() -> void:
+    game_state.award_badge("Safety")
+    _return_to_hub()
+
+func _on_back_pressed() -> void:
+    _return_to_hub()
+
+func _return_to_hub() -> void:
+    get_tree().change_scene_to_file("res://scenes/CityHub.tscn")

--- a/game/scripts/game_state.gd
+++ b/game/scripts/game_state.gd
@@ -1,0 +1,21 @@
+extends Node
+
+signal badge_awarded(badge_name: String)
+
+var _badges: Dictionary = {}
+
+func award_badge(badge_name: String) -> void:
+    if badge_name.is_empty():
+        return
+    if not _badges.has(badge_name):
+        _badges[badge_name] = true
+        badge_awarded.emit(badge_name)
+
+func has_badge(badge_name: String) -> bool:
+    return _badges.get(badge_name, false)
+
+func clear_badges() -> void:
+    _badges.clear()
+
+func get_badges() -> Array:
+    return _badges.keys()

--- a/game/scripts/ui/backpack.gd
+++ b/game/scripts/ui/backpack.gd
@@ -1,0 +1,45 @@
+extends Control
+
+const BADGE_SLOTS := [
+    "Safety",
+    "Respect",
+    "Information",
+    "Balance",
+    "Creativity"
+]
+
+@onready var _badge_container: GridContainer = $Panel/MarginContainer/VBoxContainer/BadgeGrid
+
+func _ready() -> void:
+    _populate_badge_slots()
+    game_state.badge_awarded.connect(_on_badge_awarded)
+    visible = false
+
+func toggle_backpack() -> void:
+    visible = not visible
+
+func _populate_badge_slots() -> void:
+    for child in _badge_container.get_children():
+        child.queue_free()
+    for badge_name in BADGE_SLOTS:
+        var badge_label := Label.new()
+        badge_label.text = _format_badge_label(badge_name)
+        badge_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+        badge_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+        badge_label.size_flags_horizontal = Control.SIZE_FILL
+        badge_label.size_flags_vertical = Control.SIZE_FILL
+        _badge_container.add_child(badge_label)
+
+func _on_badge_awarded(_badge_name: String) -> void:
+    _refresh_badge_text()
+
+func _refresh_badge_text() -> void:
+    for child in _badge_container.get_children():
+        if child is Label:
+            var badge_name := child.text.split(":")[0]
+            child.text = _format_badge_label(badge_name)
+
+func _format_badge_label(badge_name: String) -> String:
+    var earned := game_state.has_badge(badge_name)
+    var status := earned ? "Earned" : "Locked"
+    return "%s: %s" % [badge_name, status]


### PR DESCRIPTION
## Summary
- initialize the Godot 4 project with a City Hub entry point and game state singleton
- add the Backpack of Wisdom UI and clickable hub map that routes to each district scene
- scaffold placeholder district scenes that award badges and return players to the hub

## Testing
- not run (Godot editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d87afa35d483228493d0fc12478b01